### PR TITLE
Please add semantic version tags and this podspec file.

### DIFF
--- a/LBActionSheet.podspec
+++ b/LBActionSheet.podspec
@@ -1,0 +1,38 @@
+Pod::Spec.new do |s|
+  s.name         = "LBActionSheet"
+  s.version      = "0.0.1"
+  s.summary      = "A very customizable drop-in replacement for UIActionSheet"
+  s.description  = <<-DESC
+                   LBActionSheet is a drop-in replacement for UIActionSheet. However, its API makes it very easy to customize it.
+                   It's designed for this sole purpose only which makes it redundant when you don't need to implement a custom theme.
+                   DESC
+
+  s.homepage     = "https://github.com/larcus94/LBActionSheet"
+  s.license      = { :type => 'MIT', :text => <<-LICENSE
+                                                Permission is hereby granted, free of charge, to any person obtaining a copy
+                                                of this software and associated documentation files (the "Software"), to deal
+                                                in the Software without restriction, including without limitation the rights
+                                                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                                                copies of the Software, and to permit persons to whom the Software is
+                                                furnished to do so, subject to the following conditions:
+
+                                                The above copyright notice and this permission notice shall be included in
+                                                all copies or substantial portions of the Software.
+
+                                                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                                                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                                                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                                                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                                                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                                                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+                                                THE SOFTWARE.
+                                              LICENSE
+                                              }
+
+  s.author       = "Laurin Brandner"
+  s.platform     = :ios, '5.0'
+  s.source       = { :git => "https://github.com/larcus94/LBActionSheet.git", :commit => "88bcd764f4285d700a150b62861e0a53542386dd" }
+  s.source_files  = 'LBActionSheet'
+  s.framework  = 'CoreImage'
+  s.requires_arc = true
+end


### PR DESCRIPTION
I’ve recently added [LBActionSheet](https://github.com/CocoaPods/Specs/tree/master/LBActionSheet) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, LBActionSheet doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
